### PR TITLE
Fixed :D

### DIFF
--- a/src/avro.nim
+++ b/src/avro.nim
@@ -4,4 +4,7 @@
 import avropkg/main
 
 when isMainModule:
+  echo(parse("amar nam tanim"))
+  echo(parse("ki khobor? kemon acho?"))
   echo(parse("ami banglay gan gai"))
+


### PR DESCRIPTION
It looks like there was no `IndexDefect` at all.
Fixed:
- typos (`replaced` to `replace`)
- indexes
- reassigned modified values to variables

Did some tests. Heres the output:
`amar nam tanim` -> `আমার নাম তানিম`
`ki khobor? kemon acho?` -> `কি খবর? কেমন আছ?`

looks OK, ig.
lemme know if you run into trouble :P
